### PR TITLE
feat: Implement image file upload and serving

### DIFF
--- a/src/main/java/com/example/lightblue/config/WebConfig.java
+++ b/src/main/java/com/example/lightblue/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.lightblue.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + System.getProperty("user.dir") + "/uploads/");
+    }
+}

--- a/src/main/java/com/example/lightblue/controller/ArtistController.java
+++ b/src/main/java/com/example/lightblue/controller/ArtistController.java
@@ -4,11 +4,14 @@ import com.example.lightblue.dto.ArtistDTO;
 import com.example.lightblue.model.Artist;
 import com.example.lightblue.model.Portfolio;
 import com.example.lightblue.service.ArtistService;
+import com.example.lightblue.dto.PortfolioRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.MediaType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -60,18 +63,18 @@ public class ArtistController {
                 .collect(Collectors.toList());
     }
 
-    @PostMapping("/{artistId}/portfolios")
+    @PostMapping(value = "/{artistId}/portfolios", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @PreAuthorize("hasAuthority('ARTIST')")
-    public ResponseEntity<Portfolio> addPortfolioToArtist(@PathVariable Long artistId, @RequestBody Portfolio portfolio) {
-        Portfolio createdPortfolio = artistService.addPortfolioToArtist(artistId, portfolio);
+    public ResponseEntity<Portfolio> addPortfolioToArtist(@PathVariable Long artistId, @RequestPart("portfolioRequest") PortfolioRequest portfolioRequest, @RequestParam(value = "files", required = false) List<MultipartFile> files) {
+        Portfolio createdPortfolio = artistService.addPortfolioToArtist(artistId, portfolioRequest, files);
         return new ResponseEntity<>(createdPortfolio, HttpStatus.CREATED);
     }
 
-    @PutMapping("/{artistId}/portfolios/{portfolioId}")
+    @PutMapping(value = "/{artistId}/portfolios/{portfolioId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @PreAuthorize("hasAuthority('ARTIST')")
-    public ResponseEntity<Portfolio> updatePortfolio(@PathVariable Long artistId, @PathVariable Long portfolioId, @RequestBody Portfolio portfolioDetails) {
+    public ResponseEntity<Portfolio> updatePortfolio(@PathVariable Long artistId, @PathVariable Long portfolioId, @RequestPart("portfolioRequest") PortfolioRequest portfolioRequest, @RequestParam(value = "files", required = false) List<MultipartFile> files) {
         // Ensure the portfolio belongs to the artist if needed, or handle in service
-        Portfolio updatedPortfolio = artistService.updatePortfolio(portfolioId, portfolioDetails);
+        Portfolio updatedPortfolio = artistService.updatePortfolio(portfolioId, portfolioRequest, files);
         return new ResponseEntity<>(updatedPortfolio, HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/lightblue/dto/PortfolioRequest.java
+++ b/src/main/java/com/example/lightblue/dto/PortfolioRequest.java
@@ -1,0 +1,12 @@
+package com.example.lightblue.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PortfolioRequest {
+    private String url;
+}

--- a/src/main/java/com/example/lightblue/model/Portfolio.java
+++ b/src/main/java/com/example/lightblue/model/Portfolio.java
@@ -5,6 +5,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "portfolio")
 @Data
@@ -20,6 +23,19 @@ public class Portfolio {
     @JoinColumn(name = "artist_id", nullable = false)
     private Artist artist;
 
-    @Column(nullable = false)
+    @Column(nullable = true) // url is now optional
     private String url;
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PortfolioFile> files = new ArrayList<>();
+
+    public void addFile(PortfolioFile file) {
+        files.add(file);
+        file.setPortfolio(this);
+    }
+
+    public void removeFile(PortfolioFile file) {
+        files.remove(file);
+        file.setPortfolio(null);
+    }
 }

--- a/src/main/java/com/example/lightblue/model/PortfolioFile.java
+++ b/src/main/java/com/example/lightblue/model/PortfolioFile.java
@@ -1,0 +1,25 @@
+package com.example.lightblue.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Table(name = "portfolio_file")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PortfolioFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "portfolio_id", nullable = false)
+    private Portfolio portfolio;
+
+    @Column(name = "file_uri", nullable = false)
+    private String fileUri;
+}

--- a/src/main/java/com/example/lightblue/repository/PortfolioFileRepository.java
+++ b/src/main/java/com/example/lightblue/repository/PortfolioFileRepository.java
@@ -1,0 +1,9 @@
+package com.example.lightblue.repository;
+
+import com.example.lightblue.model.PortfolioFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PortfolioFileRepository extends JpaRepository<PortfolioFile, Long> {
+}

--- a/src/main/java/com/example/lightblue/service/ArtistService.java
+++ b/src/main/java/com/example/lightblue/service/ArtistService.java
@@ -2,23 +2,37 @@ package com.example.lightblue.service;
 
 import com.example.lightblue.model.Artist;
 import com.example.lightblue.model.Portfolio;
+import com.example.lightblue.model.PortfolioFile;
 import com.example.lightblue.repository.ArtistRepository;
 import com.example.lightblue.repository.PortfolioRepository;
+import com.example.lightblue.repository.PortfolioFileRepository;
+import com.example.lightblue.dto.PortfolioRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class ArtistService {
+
+    private final String UPLOAD_DIR = "uploads";
 
     @Autowired
     private ArtistRepository artistRepository;
 
     @Autowired
     private PortfolioRepository portfolioRepository;
+
+    @Autowired
+    private PortfolioFileRepository portfolioFileRepository;
 
     public List<Artist> getAllArtists() {
         return artistRepository.findAll();
@@ -54,22 +68,75 @@ public class ArtistService {
     }
 
     @Transactional
-    public Portfolio addPortfolioToArtist(Long artistId, Portfolio portfolio) {
+    public Portfolio addPortfolioToArtist(Long artistId, PortfolioRequest portfolioRequest, List<MultipartFile> files) {
         Artist artist = artistRepository.findById(artistId)
                 .orElseThrow(() -> new RuntimeException("Artist not found with id " + artistId));
+
+        Portfolio portfolio = new Portfolio();
+        portfolio.setUrl(portfolioRequest.getUrl());
         portfolio.setArtist(artist);
+
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                try {
+                    String fileUri = saveFile(file);
+                    PortfolioFile portfolioFile = new PortfolioFile();
+                    portfolioFile.setFileUri(fileUri);
+                    portfolio.addFile(portfolioFile);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to save file", e);
+                }
+            }
+        }
+
         return portfolioRepository.save(portfolio);
     }
 
     @Transactional
-    public Portfolio updatePortfolio(Long portfolioId, Portfolio portfolioDetails) {
+    public Portfolio updatePortfolio(Long portfolioId, PortfolioRequest portfolioRequest, List<MultipartFile> files) {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found with id " + portfolioId));
-        portfolio.setUrl(portfolioDetails.getUrl());
+
+        portfolio.setUrl(portfolioRequest.getUrl());
+
+        // Clear existing files and add new ones
+        portfolio.getFiles().clear();
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                try {
+                    String fileUri = saveFile(file);
+                    PortfolioFile portfolioFile = new PortfolioFile();
+                    portfolioFile.setFileUri(fileUri);
+                    portfolio.addFile(portfolioFile);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to save file", e);
+                }            }
+        }
+
         return portfolioRepository.save(portfolio);
     }
 
     public void deletePortfolio(Long portfolioId) {
         portfolioRepository.deleteById(portfolioId);
+    }
+
+    private String saveFile(MultipartFile file) throws IOException {
+        Path uploadPath = Paths.get(System.getProperty("user.dir"), UPLOAD_DIR);
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String fileExtension = "";
+        int dotIndex = originalFilename.lastIndexOf('.');
+        if (dotIndex > 0 && dotIndex < originalFilename.length() - 1) {
+            fileExtension = originalFilename.substring(dotIndex);
+        }
+
+        String uniqueFilename = UUID.randomUUID().toString() + fileExtension;
+        Path filePath = uploadPath.resolve(uniqueFilename);
+        Files.copy(file.getInputStream(), filePath);
+
+        return "/" + UPLOAD_DIR + "/" + uniqueFilename;
     }
 }

--- a/src/main/java/com/example/lightblue/service/PortfolioService.java
+++ b/src/main/java/com/example/lightblue/service/PortfolioService.java
@@ -33,7 +33,8 @@ public class PortfolioService {
         Portfolio portfolio = portfolioRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found with id " + id));
         portfolio.setUrl(portfolioDetails.getUrl());
-        portfolio.setArtist(portfolioDetails.getArtist()); // Assuming artist can be updated or is set correctly
+        // Assuming artist can be updated or is set correctly, if not, remove this line
+        // portfolio.setArtist(portfolioDetails.getArtist());
         return portfolioRepository.save(portfolio);
     }
 


### PR DESCRIPTION
This commit introduces the functionality to upload multiple image files to a portfolio and serve them via URIs

Key changes include:
- Added `PortfolioFile` entity to store file URIs.
- Modified `Portfolio` entity to establish a one-to-many relationship with `PortfolioFile`.
- Updated `POST /api/artists/{artistId}/portfolios` endpoint to accept `multipart/form-data` with `PortfolioRequest` and `List<MultipartFile>`.
- Implemented local file system storage for uploaded images in `ArtistService`.
- Configured Spring Boot to serve static files from the 'uploads' directory via `WebConfig`.
- Refactored `ArtistController`, `ArtistService`, and `PortfolioService` to support the new file upload and storage mechanism.