### PR TITLE
feat: Implement OAuth2 login

### DIFF
--- a/src/main/java/com/example/lightblue/model/Account.java
+++ b/src/main/java/com/example/lightblue/model/Account.java
@@ -1,14 +1,10 @@
 package com.example.lightblue.model;
 
-import jakarta.persistence.*;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -36,6 +32,12 @@ public class Account implements UserDetails {
 
     @Column(name = "account_type", nullable = false)
     private String accountType;
+
+    @Column(nullable = true)
+    private String nickname;
+
+    @Column(name = "profile_image", nullable = true)
+    private String profileImage;
 
     @OneToOne(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Artist artist;

--- a/src/main/java/com/example/lightblue/service/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/lightblue/service/oauth2/CustomOAuth2UserService.java
@@ -1,8 +1,9 @@
 package com.example.lightblue.service.oauth2;
 
+import com.example.lightblue.global.code.status.ErrorStatus;
+import com.example.lightblue.global.exception.GeneralException;
 import com.example.lightblue.model.Account;
 import com.example.lightblue.repository.AccountRepository;
-import com.example.lightblue.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -12,8 +13,8 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -21,7 +22,6 @@ import java.util.Map;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final AccountRepository accountRepository;
-    private final AuthService authService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -34,24 +34,47 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         log.info("userNameAttributeName: {}", userNameAttributeName);
         log.info("oAuth2User attributes: {}", oAuth2User.getAttributes());
 
-        // Naver specific user info extraction
+        String email = null;
+        String nickname = null;
+        String profileImage = null;
+
         if ("naver".equals(registrationId)) {
             Map<String, Object> response = (Map<String, Object>) oAuth2User.getAttributes().get("response");
-            String email = (String) response.get("email");
-            String nickname = (String) response.get("nickname");
-            String profileImage = (String) response.get("profile_image");
-
-            log.info("Naver User Info - Email: {}, Nickname: {}, Profile Image: {}", email, nickname, profileImage);
-
-            Account account = authService.registerOrUpdateOAuth2User(email, nickname, profileImage);
-
-            return new DefaultOAuth2User(
-                    account.getAuthorities(),
-                    oAuth2User.getAttributes(),
-                    userNameAttributeName
-            );
+            email = (String) response.get("email");
+            nickname = (String) response.get("nickname");
+            profileImage = (String) response.get("profile_image");
+        } else if ("google".equals(registrationId)) {
+            email = oAuth2User.getAttribute("email");
+            nickname = oAuth2User.getAttribute("name");
+            profileImage = oAuth2User.getAttribute("picture");
         }
 
-        return new DefaultOAuth2User(Collections.emptyList(), oAuth2User.getAttributes(), userNameAttributeName);
+        if (email == null) {
+            throw new GeneralException(ErrorStatus.EMAIL_NOT_FOUND);
+        }
+
+        final String finalEmail = email;
+        final String finalNickname = nickname;
+        final String finalProfileImage = profileImage;
+
+        Account account = accountRepository.findByUsername(email)
+                .orElseGet(() -> {
+                    if (accountRepository.findByUsername(finalEmail).isPresent()) {
+                        throw new GeneralException(ErrorStatus.EMAIL_DUPLICATE);
+                    }
+                    Account newAccount = new Account();
+                    newAccount.setUsername(finalEmail);
+                    newAccount.setPassword(UUID.randomUUID().toString());
+                    newAccount.setAccountType("NORMAL");
+                    newAccount.setNickname(finalNickname);
+                    newAccount.setProfileImage(finalProfileImage);
+                    return accountRepository.save(newAccount);
+                });
+
+        return new DefaultOAuth2User(
+                account.getAuthorities(),
+                oAuth2User.getAttributes(),
+                userNameAttributeName
+        );
     }
 }


### PR DESCRIPTION
- Added `oauth2LoginSuccessHandler` in `SecurityConfig` to process successful OAuth2 logins, generate JWT tokens, and return them to the client.
- Extended `Account` model with `nickname` and `profileImage` fields to store user information from OAuth2 providers.
- Implemented logic to either find an existing account or register a new one based on the OAuth2 provided email, including handling duplicate email scenarios.